### PR TITLE
show proper endtime when switching market

### DIFF
--- a/src/javascript/pages/bet/bet_form/time.js
+++ b/src/javascript/pages/bet/bet_form/time.js
@@ -294,9 +294,13 @@ BetForm.TradingTime.prototype = {
         if(moment.utc().isSame(ms, 'day')) {
             expiry_time = ms.format('HH:mm');
         }
+        if(!moment.utc().isSame(ms, 'day')) {
+            var trading_times = this.get_trading_times(ms.format('YYYY-MM-DD'));
+            expiry_time = moment.utc(trading_times.closing);
+        }
         return {
             expiry_date: ms.format('YYYY-MM-DD'),
-            expiry_time: expiry_time,
+            expiry_time: expiry_time.format('HH:mm:ss'),
             moment: ms
         };
     },


### PR DESCRIPTION
This has been there for a while. I am glad that we finally fix it.
