### PR TITLE
expose current auth token to enable direct api impersonation

### DIFF
--- a/src/templates/toolkit/account/settings.html.tt
+++ b/src/templates/toolkit/account/settings.html.tt
@@ -14,4 +14,6 @@
     [% IF show_self_exclusion %]
         <p>[% loadstring.fpartics_selfexclusionlimitsdescription %]</p>
     [% END %]
+
+    <p>[% l('Your API Token is: ')%] <span class="notice-msg">[% request.session_cookie.token %]</span></p>
 </div>


### PR DESCRIPTION
Wipe out some irrelevant references and modules using the term 'WebAPI'.

Related PRs:
bom: https://github.com/regentmarkets/bom/pull/368
bom-feed: https://github.com/regentmarkets/bom-feed/pull/17
bom-webapi: https://github.com/regentmarkets/bom-webapi/pull/17
binary-static: https://github.com/binary-com/binary-static/pull/167

This PR also introduces the (optional) act-for concept, where an api client can send an act-for token with the request, to indicate that this request is acting-for the original owner of that token. So far, the token is collect but not yet acted-upon by any api call.