### PR TITLE
Add TypeKit to head to prevent FOUT

### DIFF
--- a/src/templates/haml/layouts/default/head.html.haml
+++ b/src/templates/haml/layouts/default/head.html.haml
@@ -34,6 +34,10 @@
 
   %title= stash('website_name') . (stash('title') ? " : ".stash('title'): '')
 
+  %script{:src => "//use.typekit.net/bfu3ywb.js"}
+  :javascript
+    try{Typekit.load();}catch(e){}
+
   %link{:rel=>"icon" :type=>"image/png" :href=>url_for('images/common/favicon_1.ico')}
   /[if IE]
     %link{:rel=>"shortcut icon" :href=>url_for('images/common/favicon_1.ico')}

--- a/src/templates/toolkit/global/head.html.tt
+++ b/src/templates/toolkit/global/head.html.tt
@@ -20,6 +20,9 @@
         <meta property="og:type" content="website" />
         <meta property="og:image" content="[% request.url_for('images/common/og_image.gif') %]" />
 
+        <script src="//use.typekit.net/bfu3ywb.js"></script>
+        <script>try{Typekit.load();}catch(e){}</script>        
+
         <link rel="icon" type="image/png" href="[% request.url_for('images/common/favicon_1.ico') %]"/>
 
         [% FOREACH key = available_languages.keys %]


### PR DESCRIPTION
This adds the TypeKit loading code to the header, as discussed with JY.

Raunak, I don't have write access to the GTM, but on this change going live, we need to remove the corresponding entry.