### PR TITLE
All normal links are no longer green, but 'brand-blue' and bold. No other links are bold.

### DIFF
--- a/src/sass/common.scss
+++ b/src/sass/common.scss
@@ -24,8 +24,9 @@ h1, h2, h3, h4, li, p, a, span {
     text-rendering: optimizelegibility;
 }
 a, a:visited {
-    color: $COLOR_GREEN;
+    color: $COLOR_BLUE;
     text-decoration: none;
+    font-weight: bold;
     &:hover, &:active {
         text-decoration: underline;
     }
@@ -179,7 +180,7 @@ select.input {
 label {
     line-height: 25px;
 }
-// used for form label in grid structure 
+// used for form label in grid structure
 .form_label {
     text-align: right;
     line-height: 25px;

--- a/src/sass/common/footer.scss
+++ b/src/sass/common/footer.scss
@@ -7,6 +7,7 @@
     }
     a {
       font-size: 74%;
+      font-weight: normal;
       color: $COLOR_WHITE;
     }
     li {

--- a/src/sass/common/header.scss
+++ b/src/sass/common/header.scss
@@ -146,6 +146,7 @@
         background: none;
       }
       a {
+        font-weight: normal;          
         vertical-align: middle;
         display: table-cell;
         height: 50px;
@@ -166,5 +167,3 @@
     }
   }
 }
-
-

--- a/src/sass/common/nav.scss
+++ b/src/sass/common/nav.scss
@@ -18,6 +18,7 @@
       margin: 0 2em 0 0;
       display: inline-block;
       a {
+        font-weight: normal;
         color: $COLOR_BLACK;
         line-height: 2;
         top: 1px;

--- a/src/sass/mixin.scss
+++ b/src/sass/mixin.scss
@@ -41,6 +41,7 @@
         background: $COLOR_GRAY;
       }
       a {
+        font-weight: normal;
         text-decoration: none;
         display: block;
         padding: 5px 5px 5px 10px;
@@ -148,6 +149,7 @@
       padding: 0 10px;
       a, a:visited {
         padding: 0;
+        font-weight: normal;
         text-decoration: none;
         color: $COLOR_BLACK;
         font-size: 90%;
@@ -160,6 +162,7 @@
       a {
         background: none;
         color: $COLOR_WHITE;
+        font-weight: normal;
         text-decoration: none;
         padding: 0;
       }
@@ -175,6 +178,7 @@
         a {
           color: $COLOR_BLACK;
           padding-top: 0;
+          font-weight: normal;
           text-decoration: none;
           width: auto;
         }

--- a/src/sass/pages/home.scss
+++ b/src/sass/pages/home.scss
@@ -178,6 +178,7 @@
             width: auto;
             line-height:1;
             a.ticker-link {
+                font-weight: normal;
                 color: $COLOR_BLACK;
             }
           }


### PR DESCRIPTION
Part of moving design improvements from redesign to main site.