### PR TITLE
bet_price: keep info_for_display and applicable_ticks in sync

### DIFF
--- a/src/javascript/binary/pages/bet/bet_price.js
+++ b/src/javascript/binary/pages/bet/bet_price.js
@@ -180,6 +180,7 @@ var BetPrice = function() {
                     $self.ev.close();
                     $self.digit_tick_count = 0;
                     $self.applicable_ticks = [];
+                    $self.info_for_display = [];
                 },
                 process: function(start_moment) {
                     var $self = this;


### PR DESCRIPTION
It seems like we are getting extra ticks (which are renumbered to the
"start" of the contract) because the signal used to know when to stop
displaying (applicable_ticks) is not kept in sync with the actual source
of the data.

This doesn't _seem_ quite right, but it may be a problem in a small,
racy corner case.  It's essentially impossible to reproduce on demand
and testing is even more difficult, so we'll assume this is good enough
until it is not.