### PR TITLE
instead of storing url, stores channel name now

### DIFF
--- a/src/javascript/binary/pages/bet/bet_price.js
+++ b/src/javascript/binary/pages/bet/bet_price.js
@@ -521,7 +521,8 @@ var BetPrice = function() {
                     BetForm.spot.clear_sparkline();
                     this.stop();
                     update_from_stream = true;
-                    var url = this.url();
+                    var stream_channel = this.stream_channel();
+                    var url = window.location.protocol + '//' + page.settings.get('streaming_server')+'/push/price/'+stream_channel;
                     if(url && typeof (EventSource) !== "undefined") {
                         price_stream = new EventSource(url, { retry: 18000000 });
                         var that = this;
@@ -542,8 +543,8 @@ var BetPrice = function() {
                 ignore_updates: function() {
                     update_from_stream = false;
                 },
-                url: function() {
-                    return $('#stream_url').html();
+                stream_channel: function() {
+                    return $('#stream_channel').html();
                 },
                 process_message: function(data) {
                     if(data == 'stop_bet') {


### PR DESCRIPTION
This is because url can have decimals for spread and it is causing a
problem.