### PR TITLE
binary-maksym/ws-trading-page-fixes

### DIFF
--- a/src/javascript/binary/pages/trade/common.js
+++ b/src/javascript/binary/pages/trade/common.js
@@ -328,29 +328,6 @@ function displayCommentPrice(id, currency, type, payout) {
 }
 
 /*
- * function to filter out allowed markets from all markets
- */
-function getAllowedMarkets(markets) {
-    'use strict';
-    if (markets && getCookieItem('loginid')) {
-        var obj = {};
-        var allowedMarkets = getCookieItem('allowed_markets');
-        if (allowedMarkets) {
-            for (var key in markets) {
-                if (markets.hasOwnProperty(key)) {
-                    var re = new RegExp(key, 'i');
-                    if (re.test(allowedMarkets)) {
-                        obj[key] = markets[key];
-                    }
-                }
-            }
-            return obj;
-        }
-    }
-    return markets;
-}
-
-/*
  * This function loops through the available contracts and markets
  * that are not supposed to be shown are replaced
  *

--- a/src/javascript/binary/pages/trade/price.js
+++ b/src/javascript/binary/pages/trade/price.js
@@ -148,7 +148,7 @@ var Price = (function () {
             para.setAttribute('class', 'notice-msg');
             fragment.appendChild(para);
         } else {
-            displayCommentPrice('price_comment_' + position, currency.value, proposal['ask_price'], document.getElementById('amount').value);
+            displayCommentPrice('price_comment_' + position, currency.value, proposal['ask_price'], proposal['payout']);
 
             var priceId = document.getElementById('purchase_button_' + position);
 

--- a/src/javascript/binary/pages/trade/process.js
+++ b/src/javascript/binary/pages/trade/process.js
@@ -13,7 +13,7 @@ function processActiveSymbols() {
     // store the market
     sessionStorage.setItem('market', market);
 
-    displayOptions('contract_markets', getAllowedMarkets(Symbols.markets()), market);
+    displayOptions('contract_markets', Symbols.markets(), market);
     processMarket();
     setTimeout(function(){
         var underlying = document.getElementById('underlying').value;


### PR DESCRIPTION
Fixes:

- fixed contract buy description
- cleaned function of comparing markets from ws active_symbols answer with markerts from cookies. Markets list from active_symbols request is considered to be always correct