### PR TITLE
Negar/japan privacy link

### DIFF
--- a/src/templates/haml/layouts/default/footer.html.haml
+++ b/src/templates/haml/layouts/default/footer.html.haml
@@ -56,8 +56,10 @@
                   %a.pjaxload{:href=>url_for("/terms-and-conditions")}= l('Terms and Conditions')
                 %li.hidden.ja-show-block
                   %a.pjaxload{:href=>url_for("/terms-and-conditions-jp")}= l('Terms and Conditions')
-                %li
+                %li.ja-hide
                   %a.pjaxload{:href=>url_for("/terms-and-conditions#privacy-tab")}= l('Security and Privacy')
+                %li.hidden.ja-show-block
+                  %a.pjaxload{:href=>url_for("/terms-and-conditions-jp?selected_tab=privacy-tab")}= l('Security and Privacy')
                 %li.ja-hide
                   %a.pjaxload{:href=>url_for("responsible-trading")}= l('Responsible Trading')
                 %li.ja-hide

--- a/src/templates/toolkit/global/footer.html.tt
+++ b/src/templates/toolkit/global/footer.html.tt
@@ -114,9 +114,15 @@
                             IF
                             target %] target="[% target %]"[% END %]>[% l('Terms and Conditions') %]</a>
                         </li>
-                        <li>
+                        <li class='ja-hide'>
                             <a class="pjaxload"
                                href="[% request.url_for('/terms-and-conditions') %]#privacy-tab"[% IF
+                            target
+                            %] target="[% target %]"[% END %]>[% l('Security and Privacy') %]</a>
+                        </li>
+                        <li class='hidden ja-show-block'>
+                            <a class="pjaxload"
+                               href="[% request.url_for('/terms-and-conditions-jp') %]?selected_tab=privacy-tab"[% IF
                             target
                             %] target="[% target %]"[% END %]>[% l('Security and Privacy') %]</a>
                         </li>

--- a/src/templates/toolkit/global/footer.html.tt
+++ b/src/templates/toolkit/global/footer.html.tt
@@ -122,7 +122,7 @@
                         </li>
                         <li class='hidden ja-show-block'>
                             <a class="pjaxload"
-                               href="[% request.url_for('/terms-and-conditions-jp') %]?selected_tab=privacy-tab"[% IF
+                               href="[% request.url_for('/terms-and-conditions-jp?selected_tab=privacy-tab') %]"[% IF
                             target
                             %] target="[% target %]"[% END %]>[% l('Security and Privacy') %]</a>
                         </li>


### PR DESCRIPTION
change the privacy link in the footer to point to japan's legal pages for japan language