### PR TITLE
nuru/pricing_table(Stopping users from keydown in date field)

### DIFF
--- a/src/javascript/binary/pages/pricingtable.js
+++ b/src/javascript/binary/pages/pricingtable.js
@@ -129,6 +129,7 @@ function initialize_pricing_table() {
     select_underlying_change();
     select_strike_type();
     expiry_date_picker();
+    $("#from_expiry").keydown(false);
 }
 
 onLoad.queue_for_url(initialize_pricing_table, 'pricing_table');


### PR DESCRIPTION
Hi,

Just a little fix on our pricing table. We want to stop users from keyboard input, only select using the datepicker