### PR TITLE
sy/pwd_pattern

### DIFF
--- a/src/javascript/binary/static/common/validation.js
+++ b/src/javascript/binary/static/common/validation.js
@@ -61,7 +61,7 @@ var Validate = (function(){
 
             return false;
 
-        } else if (!/^[^-~\s]+$/.test(password)) {
+        } else if (!/^[ -~]+$/.test(password)) {
             hideErrorMessage(rError);
             error.textContent = Content.errorMessage('valid', Content.localize().textPassword);
             displayErrorMessage(error);


### PR DESCRIPTION
Allow broader password pattern for below forms:

- VR a/c signup
- change password
- new password (forgot password)
- cashier password

HTML::FormBuilder will encode / decode entities of char like " ' < > 

During $form->validate fail, the password is echoed back correctly to client, eliminating HTML attribute injection problem.


PR:
https://github.com/binary-com/perl-HTML-FormBuilder/pull/13


https://github.com/regentmarkets/bom-web/pull/316
https://github.com/regentmarkets/bom-platform/pull/192
https://github.com/regentmarkets/cpan/pull/152
https://github.com/regentmarkets/bom-websocket-api/pull/338
https://github.com/binary-com/binary-static/pull/821
