### PR TITLE
Fix for error on negative values in barrier offset

### DIFF
--- a/src/templates/toolkit/bet/static.html.tt
+++ b/src/templates/toolkit/bet/static.html.tt
@@ -79,7 +79,7 @@
                            </label>
                         </div>
                         <div class="big-col">
-                           <input id="barrier" type="text" name="H" pattern="^\+\d+(\.\d{1,5})?|\d+(\.\d{1,5})?$" title="maximum of 5 decimal points allowed" />
+                           <input id="barrier" type="text" name="H" pattern="^[\+-]\d+(\.\d{1,5})?|\d+(\.\d{1,5})?$" title="maximum of 5 decimal points allowed" />
                            <abbr rel="tooltip" id="indicative_barrier_tooltip"></abbr>
                         </div>
                      </div>


### PR DESCRIPTION
Fix for this [Trello card](https://trello.com/c/2QbCUVFc/118-invalid-error-message-when-change-positive-to-negative-barrier)