### PR TITLE
Unexpected error due to addComma()

### DIFF
--- a/src/javascript/binary/pages/openpositionsws.js
+++ b/src/javascript/binary/pages/openpositionsws.js
@@ -118,7 +118,7 @@ var PortfolioWS =  (function() {
 
         indicative_sum = indicative_sum.toFixed(2);
 
-        $("#value-of-open-positions").text('USD ' + addComma(parseFloat(indicative_sum).toFixed(2)));
+        $("#value-of-open-positions").text('USD ' + parseFloat(indicative_sum).toFixed(2));
 
     };
 


### PR DESCRIPTION
The call to `addComma()` resulted in error because a string was passed instead of a float. Removed it from the call to avoid error!