### PR TITLE
stop ticktrade behaviour for endtime purchase

### DIFF
--- a/src/javascript/binary/pages/trade/price.js
+++ b/src/javascript/binary/pages/trade/price.js
@@ -81,6 +81,8 @@ var Price = (function() {
             }
 
             proposal['date_expiry'] = moment.utc(endDate2 + " " + endTime2).unix();
+            // For stopping tick trade behaviour
+            proposal['duration_unit'] = "m";
         }
 
         if (barrier && isVisible(barrier) && barrier.value) {


### PR DESCRIPTION
When the duration type is changed to tick trade the `data-duration_unit` would change to `t`. But when `Duration` is changed to `End Time`, `data-duration_unit` would still be `t` which caused the `endtime` contracts to look like `tick trade` in web ui.
Related [Trello card](https://trello.com/c/YVbS3Psp/128-contract-is-ended-before-the-contract-end-time).