### PR TITLE
reality_check-fix

### DIFF
--- a/src/templates/haml/user/reality_check.html.haml
+++ b/src/templates/haml/user/reality_check.html.haml
@@ -43,7 +43,7 @@
     - }
   %p
     %label= l('Reality Check Interval:')
-    %input{:type => 'text' :interval => 1 :size => '6' :id =>'realityDuration'}
+    %input{:type => 'text' :interval => 1 :size => '6' :maxlength => '4' :id =>'realityDuration'}
     %span= l('minutes')
   %p.msg{:style => 'display:none; color:red;'}= l('Please enter a number greater than 0');
 %div#reality-check-nav

--- a/src/templates/haml/user/reality_check_frequency.html.haml
+++ b/src/templates/haml/user/reality_check_frequency.html.haml
@@ -5,7 +5,7 @@
 
   %p
     = l('Please specify your preferred reality-check interval in minutes ')
-    %input{:type => 'text' :interval => 1 :size => '6' :id => 'realityDuration'}
+    %input{:type => 'text' :interval => 1 :size => '6' :maxlength => '4' :id => 'realityDuration'}
 
   %p.msg{:style => 'display:none; color:red;'}= l('Please enter a number greater than 0');
 


### PR DESCRIPTION
Reality check popup would keep on appearing again and again for large inputs (input >35800). This happened due to `window.setTimeout()` accepting `32bit integers` whose largest value would be `2147483647` in miliseconds. Changing the input limit to 4 digits is the suggested fix.
Related [Trello Card](https://trello.com/c/eWeNzONc/156-reality-check-interval-validation-is-not-working-properly).