### PR TITLE
Add appId for tests to pass

### DIFF
--- a/src/javascript/binary/common_functions/__tests__/active_symbols.js
+++ b/src/javascript/binary/common_functions/__tests__/active_symbols.js
@@ -1,10 +1,6 @@
-const expect = require('chai').expect;
+const deep = require('deep-diff'); // eslint-disable-line import/no-extraneous-dependencies
 const activeSymbols = require('../active_symbols').ActiveSymbols;
-const ws = require('ws');
-const LiveApi = require('binary-live-api').LiveApi;
-const deep = require('deep-diff');
-
-const api = new LiveApi({ websocket: ws });
+const { api, expect } = require('../../common_functions/tests');
 
 /*
     There is a market called forex, which has a submarket called major_pairs, which has a symbol called frxEURUSD

--- a/src/javascript/binary/common_functions/tests.js
+++ b/src/javascript/binary/common_functions/tests.js
@@ -1,0 +1,8 @@
+const expect = require('chai').expect; // eslint-disable-line import/no-extraneous-dependencies
+const websocket = require('ws'); // eslint-disable-line import/no-extraneous-dependencies
+const { LiveApi } = require('binary-live-api'); // eslint-disable-line import/no-extraneous-dependencies
+
+module.exports = {
+    api: new LiveApi({ websocket, appId: 1 }),
+    expect,
+};

--- a/src/javascript/binary/websocket_pages/resources/__tests__/asset_indexws.js
+++ b/src/javascript/binary/websocket_pages/resources/__tests__/asset_indexws.js
@@ -1,9 +1,5 @@
-const expect      = require('chai').expect;
 const asset_index = require('../asset_indexws');
-const ws          = require('ws');
-const LiveApi     = require('binary-live-api').LiveApi;
-
-const api = new LiveApi({ websocket: ws });
+const { api, expect } = require('../../../common_functions/tests');
 
 describe('Asset Index', function() {
     let asset_index_res,

--- a/src/javascript/binary/websocket_pages/resources/__tests__/market_timesws.js
+++ b/src/javascript/binary/websocket_pages/resources/__tests__/market_timesws.js
@@ -1,9 +1,5 @@
-const expect       = require('chai').expect;
 const market_times = require('../market_timesws');
-const ws           = require('ws');
-const LiveApi      = require('binary-live-api').LiveApi;
-
-const api = new LiveApi({ websocket: ws });
+const { api, expect } = require('../../../common_functions/tests');
 
 describe('Trading Times', function() {
     let trading_times_res,

--- a/src/javascript/binary/websocket_pages/user/account/__tests__/portfolio.js
+++ b/src/javascript/binary/websocket_pages/user/account/__tests__/portfolio.js
@@ -1,9 +1,6 @@
-const expect    = require('chai').expect;
 const portfolio = require('../portfolio').Portfolio;
-const ws        = require('ws');
-const LiveApi   = require('binary-live-api').LiveApi;
+const { api, expect } = require('../../../../common_functions/tests');
 
-const api = new LiveApi({ websocket: ws });
 const portfolio_mock_data = {
     symbol        : 'frxAUDJPY',
     shortcode     : 'CALL_FRXAUDJPY_10_1467352741_1467388741_S0P_0',

--- a/src/javascript/binary/websocket_pages/user/account/__tests__/profit_table.js
+++ b/src/javascript/binary/websocket_pages/user/account/__tests__/profit_table.js
@@ -1,9 +1,5 @@
-const expect      = require('chai').expect;
 const profitTable = require('../profit_table');
-const ws          = require('ws');
-const LiveApi     = require('binary-live-api').LiveApi;
-
-const api = new LiveApi({ websocket: ws });
+const { api, expect } = require('../../../../common_functions/tests');
 
 describe('Profit Table', function() {
     let profit_table;

--- a/src/javascript/binary/websocket_pages/user/account/__tests__/statement.js
+++ b/src/javascript/binary/websocket_pages/user/account/__tests__/statement.js
@@ -1,9 +1,5 @@
-const expect    = require('chai').expect;
 const statement = require('../statement');
-const ws        = require('ws');
-const LiveApi   = require('binary-live-api').LiveApi;
-
-const api = new LiveApi({ websocket: ws });
+const { api, expect } = require('../../../../common_functions/tests');
 
 describe('Statement', function() {
     let statement_ws;


### PR DESCRIPTION
- Add `appId` to `LiveApi` in tests
- Instatiate `LiveApi` in `common_functions/tests.js`
- move `expect`, `ws`, and `LiveApi` imports to `common_functions/tests.js`
