### PR TITLE
zaki/remove_apple_markets_dropdown_search

### DIFF
--- a/scripts/generate-static-data.js
+++ b/scripts/generate-static-data.js
@@ -152,7 +152,7 @@ const texts = [
     'High-Close',
     'Close-Low',
     'High-Low',
-    '"AUD/JPY" or "Apple"',
+    '"AUD/JPY"',
     'Select Asset',
 
     // limits

--- a/src/javascript/app/pages/trade/markets.jsx
+++ b/src/javascript/app/pages/trade/markets.jsx
@@ -396,7 +396,7 @@ class Markets extends React.Component {
                             type='text'
                             maxLength={20}
                             onInput={searchSymbols}
-                            placeholder={localize('"AUD/JPY" or "Apple"')}
+                            placeholder={localize('"AUD/JPY"')}
                             value={query}
                         />
                         <span className='icon' />


### PR DESCRIPTION
Changelog
- Removed "Apple" string from Markets dropdown search field.