### PR TITLE
Refactor `Drawer` class

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,6 @@ module.exports = {
         'react/jsx-indent'                  : ['error', 4],
         'react/jsx-indent-props'            : ['error', 4],
         'react/jsx-max-props-per-line'      : ['error', { when: 'multiline' }],
-        'react/prop-types'                  : 0,
         'react/self-closing-comp'           : 'error',
     },
     extends: [

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "mobx-utils": "3.2.2",
     "moment": "2.19.4",
     "promise-polyfill": "6.1.0",
-    "prop-types": "^15.6.1",
+    "prop-types": "15.6.1",
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "react-perfect-scrollbar": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "mobx-utils": "3.2.2",
     "moment": "2.19.4",
     "promise-polyfill": "6.1.0",
+    "prop-types": "^15.6.1",
     "react": "16.2.0",
     "react-dom": "16.2.0",
     "react-perfect-scrollbar": "1.0.0",

--- a/src/javascript/app/pages/trade/contracts.jsx
+++ b/src/javascript/app/pages/trade/contracts.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 import Defaults from './defaults';
 import {getElementById} from '../../../_common/common_functions';
 import {localize} from '../../../_common/localize';
@@ -174,5 +175,10 @@ export const init = (contracts, contracts_tree) => ReactDOM.render(
     getElementById('contract_component')
 );
 /* eslint-enable react/no-render-return-value */
+
+Contracts.propTypes = {
+    contracts     : PropTypes.string,
+    contracts_tree: PropTypes.string,
+};
 
 export default init;

--- a/src/javascript/app_2/components/elements/arrowhead.jsx
+++ b/src/javascript/app_2/components/elements/arrowhead.jsx
@@ -1,9 +1,14 @@
-import React from 'react';
+import React     from 'react';
+import PropTypes from 'prop-types';
 
 const Arrowhead = ({ className }) => (
     <svg className={className} width='16' height='16' xmlns='http://www.w3.org/2000/svg'>
         <path className='arrow-path' d='M13.164 5.13a.5.5 0 1 1 .672.74l-5.5 5a.5.5 0 0 1-.672 0l-5.5-5a.5.5 0 0 1 .672-.74L8 9.824l5.164-4.694z' fill='#D2D3DA' fillRule='nonzero'/>
     </svg>
 );
+
+Arrowhead.propTypes = {
+    className: PropTypes.string,
+};
 
 export default Arrowhead;

--- a/src/javascript/app_2/components/elements/card_list.jsx
+++ b/src/javascript/app_2/components/elements/card_list.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const CardList = ({ data_source, Card }) => (
     <div className='card-list'>
@@ -9,5 +10,10 @@ const CardList = ({ data_source, Card }) => (
         }
     </div>
 );
+
+CardList.propTypes = {
+    Card       : PropTypes.func,
+    data_source: PropTypes.array,
+};
 
 export default CardList;

--- a/src/javascript/app_2/components/elements/data_table.jsx
+++ b/src/javascript/app_2/components/elements/data_table.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React      from 'react';
 import classnames from 'classnames';
+import PropTypes  from 'prop-types';
 
 /* TODO:
       1. implement sorting by column (ASC/DESC)
@@ -81,5 +82,15 @@ class DataTable extends React.Component {
         );
     }
 }
+
+DataTable.propTypes = {
+    columns         : PropTypes.array,
+    data_source     : PropTypes.array,
+    is_full_width   : PropTypes.bool,
+    has_fixed_header: PropTypes.bool,
+    footer          : PropTypes.string,
+};
+
+
 
 export default DataTable;

--- a/src/javascript/app_2/components/elements/data_table.jsx
+++ b/src/javascript/app_2/components/elements/data_table.jsx
@@ -86,9 +86,9 @@ class DataTable extends React.Component {
 DataTable.propTypes = {
     columns         : PropTypes.array,
     data_source     : PropTypes.array,
-    is_full_width   : PropTypes.bool,
-    has_fixed_header: PropTypes.bool,
     footer          : PropTypes.string,
+    has_fixed_header: PropTypes.bool,
+    is_full_width   : PropTypes.bool,
 };
 
 

--- a/src/javascript/app_2/components/elements/drawer.jsx
+++ b/src/javascript/app_2/components/elements/drawer.jsx
@@ -220,11 +220,43 @@ const DrawerHeader = ({
     );
 };
 
+Drawer.propTypes = {
+    alignment: PropTypes.string,
+    children : PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.object,
+    ]),
+    closeBtn  : PropTypes.func,
+    footer    : PropTypes.func,
+    icon_class: PropTypes.string,
+    icon_link : PropTypes.string,
+};
+
 ToggleDrawer.propTypes = {
     alignment: PropTypes.string,
-    children : PropTypes.array,
+    children : PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.object,
+    ]),
+    footer    : PropTypes.func,
+    icon_class: PropTypes.string,
+    icon_link : PropTypes.string,
+};
+
+DrawerHeader.propTypes = {
+    alignment: PropTypes.string,
     closeBtn : PropTypes.func,
-    footer   : PropTypes.func,
+};
+
+DrawerItems.propTypes = {
+    items: PropTypes.array,
+    text : PropTypes.string,
+};
+
+DrawerItem.propTypes = {
+    href: PropTypes.string,
+    icon: PropTypes.string,
+    text: PropTypes.string,
 };
 
 module.exports = {

--- a/src/javascript/app_2/components/elements/drawer.jsx
+++ b/src/javascript/app_2/components/elements/drawer.jsx
@@ -1,5 +1,6 @@
 import classNames     from 'classnames';
 import React          from 'react';
+import PropTypes      from 'prop-types';
 import { BinaryLink } from '../../routes';
 import Url            from '../../../_common/url';
 
@@ -217,6 +218,13 @@ const DrawerHeader = ({
         }
         </React.Fragment>
     );
+};
+
+ToggleDrawer.propTypes = {
+    alignment: PropTypes.string,
+    children : PropTypes.array,
+    closeBtn : PropTypes.func,
+    footer   : PropTypes.func,
 };
 
 module.exports = {

--- a/src/javascript/app_2/components/elements/language_switcher.jsx
+++ b/src/javascript/app_2/components/elements/language_switcher.jsx
@@ -1,4 +1,5 @@
 import React        from 'react';
+import PropTypes    from 'prop-types';
 import { localize } from '../../../_common/localize';
 
 class LanguageSwitcher extends React.PureComponent {
@@ -79,6 +80,10 @@ LanguageSwitcher.defaultProps = {
         { id: 'ZH_CN', name: '简体中文' },
         { id: 'ZH_TW', name: '繁體中文' },
     ],
+};
+
+LanguageSwitcher.propTypes = {
+    languages: PropTypes.array,
 };
 
 export default LanguageSwitcher;

--- a/src/javascript/app_2/components/elements/popover.jsx
+++ b/src/javascript/app_2/components/elements/popover.jsx
@@ -34,10 +34,10 @@ class Popover extends React.Component {
 }
 
 Popover.propTypes = {
-    title    : PropTypes.string,
     alignment: PropTypes.string,
-    subtitle : PropTypes.string,
     children : PropTypes.object,
+    subtitle : PropTypes.string,
+    title    : PropTypes.string,
 };
 
 export default Popover;

--- a/src/javascript/app_2/components/elements/popover.jsx
+++ b/src/javascript/app_2/components/elements/popover.jsx
@@ -1,4 +1,5 @@
 import React        from 'react';
+import PropTypes    from 'prop-types';
 import { localize } from '../../../_common/localize';
 
 class Popover extends React.Component {
@@ -10,7 +11,7 @@ class Popover extends React.Component {
     }
 
     render() {
-        const popver = (
+        const popover = (
             <div className={`popover ${this.state.is_open ? 'open' : ''} ${this.props.alignment ? this.props.alignment : ''}`}>
                 { this.props.title && <div className='popover-title'>{localize(this.props.title)}</div> }
                 { this.props.subtitle && <div className='popover-subtitle'>{localize(this.props.subtitle)}</div> }
@@ -24,12 +25,19 @@ class Popover extends React.Component {
                         React.cloneElement(child, {
                             onMouseEnter: () => this.setState({ is_open: true }),
                             onMouseLeave: () => this.setState({ is_open: false }),
-                        }, popver)
+                        }, popover)
                     ))
                 }
             </React.Fragment>
         );
     }
 }
+
+Popover.propTypes = {
+    title    : PropTypes.string,
+    alignment: PropTypes.string,
+    subtitle : PropTypes.string,
+    children : PropTypes.object,
+};
 
 export default Popover;

--- a/src/javascript/app_2/components/elements/portfolio_drawer.jsx
+++ b/src/javascript/app_2/components/elements/portfolio_drawer.jsx
@@ -1,5 +1,6 @@
 import moment       from 'moment';
 import React        from 'react';
+import PropTypes    from 'prop-types';
 import { localize } from '../../../_common/localize';
 
 class PortfolioDrawer extends React.Component {
@@ -91,5 +92,11 @@ class PortfolioDrawer extends React.Component {
         );
     }
 }
+
+PortfolioDrawer.propTypes = {
+    subtitle : PropTypes.number,
+    children : PropTypes.object,
+    alignment: PropTypes.string,
+};
 
 module.exports = PortfolioDrawer;

--- a/src/javascript/app_2/components/elements/portfolio_drawer.jsx
+++ b/src/javascript/app_2/components/elements/portfolio_drawer.jsx
@@ -94,9 +94,12 @@ class PortfolioDrawer extends React.Component {
 }
 
 PortfolioDrawer.propTypes = {
-    alignment: PropTypes.string,
-    children : PropTypes.object,
-    subtitle : PropTypes.number,
+    alignment  : PropTypes.string,
+    children   : PropTypes.object,
+    onClick    : PropTypes.func,
+    portfolios : PropTypes.array,
+    server_time: PropTypes.object,
+    subtitle   : PropTypes.number,
 };
 
 module.exports = PortfolioDrawer;

--- a/src/javascript/app_2/components/elements/portfolio_drawer.jsx
+++ b/src/javascript/app_2/components/elements/portfolio_drawer.jsx
@@ -94,9 +94,9 @@ class PortfolioDrawer extends React.Component {
 }
 
 PortfolioDrawer.propTypes = {
-    subtitle : PropTypes.number,
-    children : PropTypes.object,
     alignment: PropTypes.string,
+    children : PropTypes.object,
+    subtitle : PropTypes.number,
 };
 
 module.exports = PortfolioDrawer;

--- a/src/javascript/app_2/components/elements/tooltip.jsx
+++ b/src/javascript/app_2/components/elements/tooltip.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React     from 'react';
+import PropTypes from 'prop-types';
 
 const Tooltip = ({
     message,
@@ -15,5 +16,11 @@ const Tooltip = ({
     </span>
 );
 
+Tooltip.propTypes = {
+    alignment: PropTypes.string,
+    children : PropTypes.string,
+    is_icon  : PropTypes.bool,
+    message  : PropTypes.string,
+};
 
 export default Tooltip;

--- a/src/javascript/app_2/components/form/button.jsx
+++ b/src/javascript/app_2/components/form/button.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const Button = ({
     id,
@@ -14,6 +15,15 @@ const Button = ({
             <span>{text}</span>
         </button>
     );
+};
+
+Button.propTypes = {
+    className  : PropTypes.string,
+    handleClick: PropTypes.func,
+    has_effect : PropTypes.bool,
+    id         : PropTypes.string,
+    is_disabled: PropTypes.bool,
+    text       : PropTypes.string,
 };
 
 export default Button;

--- a/src/javascript/app_2/components/form/date_picker.jsx
+++ b/src/javascript/app_2/components/form/date_picker.jsx
@@ -1,6 +1,7 @@
 import moment       from 'moment';
 import React        from 'react';
 import classnames   from 'classnames';
+import PropTypes    from 'prop-types';
 import ArrowHead    from '../elements/arrowhead.jsx';
 import { localize } from '../../../_common/localize';
 
@@ -62,7 +63,7 @@ class Calendar extends React.Component {
 
     componentWillReceiveProps(nextProps) {
         const date = moment(this.state.date);
-        
+
         if (date.isBefore(moment(nextProps.minDate))) {
             this.setState({
                 date: nextProps.minDate,
@@ -649,6 +650,19 @@ class DatePicker extends React.PureComponent {
 DatePicker.defaultProps = {
     dateFormat: 'YYYY-MM-DD',
     mode      : 'date',
+};
+
+DatePicker.propTypes = {
+    name         : PropTypes.string,
+    initial_value: PropTypes.string,
+    placeholder  : PropTypes.string,
+    startDate    : PropTypes.string,
+    maxDate      : PropTypes.string,
+    minDate      : PropTypes.string,
+    dateFormat   : PropTypes.string,
+    mode         : PropTypes.string,
+    onChange     : PropTypes.func,
+    showTodayBtn : PropTypes.bool,
 };
 
 export default DatePicker;

--- a/src/javascript/app_2/components/form/date_picker.jsx
+++ b/src/javascript/app_2/components/form/date_picker.jsx
@@ -653,16 +653,16 @@ DatePicker.defaultProps = {
 };
 
 DatePicker.propTypes = {
-    name         : PropTypes.string,
+    dateFormat   : PropTypes.string,
     initial_value: PropTypes.string,
-    placeholder  : PropTypes.string,
-    startDate    : PropTypes.string,
     maxDate      : PropTypes.string,
     minDate      : PropTypes.string,
-    dateFormat   : PropTypes.string,
     mode         : PropTypes.string,
+    name         : PropTypes.string,
     onChange     : PropTypes.func,
+    placeholder  : PropTypes.string,
     showTodayBtn : PropTypes.bool,
+    startDate    : PropTypes.string,
 };
 
 export default DatePicker;

--- a/src/javascript/app_2/components/form/date_picker.jsx
+++ b/src/javascript/app_2/components/form/date_picker.jsx
@@ -652,17 +652,33 @@ DatePicker.defaultProps = {
     mode      : 'date',
 };
 
+Calendar.propTypes = {
+    dateFormat      : PropTypes.string,
+    footer          : PropTypes.string,
+    handleDateChange: PropTypes.func,
+    id              : PropTypes.number,
+    initial_value   : PropTypes.string,
+    is_nativepicker : PropTypes.bool,
+    maxDate         : PropTypes.string,
+    minDate         : PropTypes.string,
+    mode            : PropTypes.string,
+    placeholder     : PropTypes.string,
+    showTodayBtn    : PropTypes.bool,
+    startDate       : PropTypes.string,
+};
+
 DatePicker.propTypes = {
-    dateFormat   : PropTypes.string,
-    initial_value: PropTypes.string,
-    maxDate      : PropTypes.string,
-    minDate      : PropTypes.string,
-    mode         : PropTypes.string,
-    name         : PropTypes.string,
-    onChange     : PropTypes.func,
-    placeholder  : PropTypes.string,
-    showTodayBtn : PropTypes.bool,
-    startDate    : PropTypes.string,
+    dateFormat     : PropTypes.string,
+    id             : PropTypes.number,
+    initial_value  : PropTypes.string,
+    is_nativepicker: PropTypes.bool,
+    maxDate        : PropTypes.string,
+    minDate        : PropTypes.string,
+    mode           : PropTypes.string,
+    name           : PropTypes.string,
+    onChange       : PropTypes.func,
+    placeholder    : PropTypes.string,
+    showTodayBtn   : PropTypes.bool,
 };
 
 export default DatePicker;

--- a/src/javascript/app_2/components/form/dropdown.jsx
+++ b/src/javascript/app_2/components/form/dropdown.jsx
@@ -174,10 +174,13 @@ const NativeSelect = ({
 
 Dropdown.propTypes = {
     is_nativepicker: PropTypes.bool,
-    list           : PropTypes.array,
-    name           : PropTypes.string,
-    onChange       : PropTypes.func,
-    value          : PropTypes.string,
+    list           : PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.object,
+    ]),
+    name    : PropTypes.string,
+    onChange: PropTypes.func,
+    value   : PropTypes.string,
 };
 
 export default Dropdown;

--- a/src/javascript/app_2/components/form/dropdown.jsx
+++ b/src/javascript/app_2/components/form/dropdown.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class Dropdown extends React.PureComponent {
     constructor(props) {
@@ -170,5 +171,13 @@ const NativeSelect = ({
         </select>
     </div>
 );
+
+Dropdown.propTypes = {
+    is_nativepicker: PropTypes.bool,
+    list           : PropTypes.array,
+    name           : PropTypes.string,
+    onChange       : PropTypes.func,
+    value          : PropTypes.string,
+};
 
 export default Dropdown;

--- a/src/javascript/app_2/components/form/dropdown.jsx
+++ b/src/javascript/app_2/components/form/dropdown.jsx
@@ -173,10 +173,23 @@ const NativeSelect = ({
 );
 
 Dropdown.propTypes = {
+    className      : PropTypes.string,
     is_nativepicker: PropTypes.bool,
     list           : PropTypes.oneOfType([
         PropTypes.array,
         PropTypes.object,
+    ]),
+    name    : PropTypes.string,
+    onChange: PropTypes.func,
+    type    : PropTypes.string,
+    value   : PropTypes.string,
+
+};
+
+NativeSelect.propTypes = {
+    list: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.array,
     ]),
     name    : PropTypes.string,
     onChange: PropTypes.func,

--- a/src/javascript/app_2/components/form/fieldset.jsx
+++ b/src/javascript/app_2/components/form/fieldset.jsx
@@ -33,6 +33,7 @@ class Fieldset extends React.PureComponent {
 Fieldset.propTypes = {
     children: PropTypes.array,
     header  : PropTypes.string,
+    icon    : PropTypes.string,
     time    : PropTypes.object,
     tooltip : PropTypes.string,
 };

--- a/src/javascript/app_2/components/form/fieldset.jsx
+++ b/src/javascript/app_2/components/form/fieldset.jsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import moment     from 'moment';
 import React      from 'react';
+import PropTypes  from 'prop-types';
 import Tooltip    from '../elements/tooltip.jsx';
 
 class Fieldset extends React.PureComponent {
@@ -28,5 +29,12 @@ class Fieldset extends React.PureComponent {
         );
     }
 }
+
+Fieldset.propTypes = {
+    time    : PropTypes.object,
+    header  : PropTypes.string,
+    tooltip : PropTypes.string,
+    children: PropTypes.array,
+};
 
 export default Fieldset;

--- a/src/javascript/app_2/components/form/fieldset.jsx
+++ b/src/javascript/app_2/components/form/fieldset.jsx
@@ -31,10 +31,10 @@ class Fieldset extends React.PureComponent {
 }
 
 Fieldset.propTypes = {
-    time    : PropTypes.object,
-    header  : PropTypes.string,
-    tooltip : PropTypes.string,
     children: PropTypes.array,
+    header  : PropTypes.string,
+    time    : PropTypes.object,
+    tooltip : PropTypes.string,
 };
 
 export default Fieldset;

--- a/src/javascript/app_2/components/form/input_field.jsx
+++ b/src/javascript/app_2/components/form/input_field.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class InputField extends React.PureComponent {
     render() {
@@ -27,5 +28,15 @@ class InputField extends React.PureComponent {
         );
     }
 }
+
+InputField.propTypes = {
+    type           : PropTypes.string,
+    number         : PropTypes.string,
+    value          : PropTypes.number,
+    onChange       : PropTypes.func,
+    is_currency    : PropTypes.bool,
+    is_nativepicker: PropTypes.bool,
+    prefix         : PropTypes.string,
+};
 
 export default InputField;

--- a/src/javascript/app_2/components/form/input_field.jsx
+++ b/src/javascript/app_2/components/form/input_field.jsx
@@ -30,13 +30,13 @@ class InputField extends React.PureComponent {
 }
 
 InputField.propTypes = {
-    type           : PropTypes.string,
-    number         : PropTypes.string,
-    value          : PropTypes.number,
-    onChange       : PropTypes.func,
     is_currency    : PropTypes.bool,
     is_nativepicker: PropTypes.bool,
+    number         : PropTypes.string,
+    onChange       : PropTypes.func,
     prefix         : PropTypes.string,
+    type           : PropTypes.string,
+    value          : PropTypes.number,
 };
 
 export default InputField;

--- a/src/javascript/app_2/components/form/input_field.jsx
+++ b/src/javascript/app_2/components/form/input_field.jsx
@@ -30,11 +30,18 @@ class InputField extends React.PureComponent {
 }
 
 InputField.propTypes = {
+    className      : PropTypes.string,
+    helper         : PropTypes.bool,
     is_currency    : PropTypes.bool,
+    is_disabled    : PropTypes.string,
     is_nativepicker: PropTypes.bool,
+    label          : PropTypes.string,
+    name           : PropTypes.string,
     number         : PropTypes.string,
     onChange       : PropTypes.func,
+    placeholder    : PropTypes.string,
     prefix         : PropTypes.string,
+    required       : PropTypes.bool,
     type           : PropTypes.string,
     value          : PropTypes.number,
 };

--- a/src/javascript/app_2/components/form/time_picker.jsx
+++ b/src/javascript/app_2/components/form/time_picker.jsx
@@ -336,12 +336,21 @@ class TimePicker extends PureComponent {
 }
 
 TimePicker.propTypes = {
-    className: PropTypes.string,
-    name     : PropTypes.string,
-    onChange : PropTypes.func,
-    padding  : PropTypes.string,
-    toggle   : PropTypes.func,
-    value    : PropTypes.string,
+    is_nativepicker: PropTypes.bool,
+    name           : PropTypes.string,
+    onChange       : PropTypes.func,
+    padding        : PropTypes.string,
+    placeholder    : PropTypes.string,
+    value          : PropTypes.object,
+};
+
+TimePickerDropdown.propTypes = {
+    className  : PropTypes.string,
+    onChange   : PropTypes.func,
+    preClass   : PropTypes.string,
+    toggle     : PropTypes.func,
+    value      : PropTypes.object,
+    value_split: PropTypes.bool,
 };
 
 export default TimePicker;

--- a/src/javascript/app_2/components/form/time_picker.jsx
+++ b/src/javascript/app_2/components/form/time_picker.jsx
@@ -1,6 +1,7 @@
 import React,
     { PureComponent } from 'react';
 import IScroll        from 'iscroll';
+import PropTypes      from 'prop-types';
 import { localize }   from '../../../_common/localize';
 
 /* TODO:
@@ -333,5 +334,14 @@ class TimePicker extends PureComponent {
         );
     }
 }
+
+TimePicker.propTypes = {
+    className: PropTypes.string,
+    value    : PropTypes.string,
+    onChange : PropTypes.func,
+    name     : PropTypes.string,
+    padding  : PropTypes.string,
+    toggle   : PropTypes.func,
+};
 
 export default TimePicker;

--- a/src/javascript/app_2/components/form/time_picker.jsx
+++ b/src/javascript/app_2/components/form/time_picker.jsx
@@ -337,11 +337,11 @@ class TimePicker extends PureComponent {
 
 TimePicker.propTypes = {
     className: PropTypes.string,
-    value    : PropTypes.string,
-    onChange : PropTypes.func,
     name     : PropTypes.string,
+    onChange : PropTypes.func,
     padding  : PropTypes.string,
     toggle   : PropTypes.func,
+    value    : PropTypes.string,
 };
 
 export default TimePicker;

--- a/src/javascript/app_2/components/layout/footer.jsx
+++ b/src/javascript/app_2/components/layout/footer.jsx
@@ -1,4 +1,5 @@
 import React          from 'react';
+import PropTypes      from 'prop-types';
 import Popover        from '../elements/popover.jsx';
 import { BinaryLink } from '../../routes';
 import { connect }    from '../../store/connect';
@@ -73,6 +74,7 @@ class ToggleFullScreen extends React.Component {
 }
 
 class Footer extends React.Component {
+
     render() {
         return (
             <React.Fragment>
@@ -96,6 +98,12 @@ class Footer extends React.Component {
         );
     }
 }
+
+Footer.propTypes = {
+    items                 : PropTypes.array,
+    is_portfolio_drawer_on: PropTypes.bool,
+    togglePortfolioDrawer : PropTypes.func,
+};
 
 export default connect(
     ({ ui }) => ({

--- a/src/javascript/app_2/components/layout/footer.jsx
+++ b/src/javascript/app_2/components/layout/footer.jsx
@@ -100,8 +100,11 @@ class Footer extends React.Component {
 }
 
 Footer.propTypes = {
+    items: PropTypes.array,
+};
+
+TogglePortfolioDrawer.propTypes = {
     is_portfolio_drawer_on: PropTypes.bool,
-    items                 : PropTypes.array,
     togglePortfolioDrawer : PropTypes.func,
 };
 

--- a/src/javascript/app_2/components/layout/footer.jsx
+++ b/src/javascript/app_2/components/layout/footer.jsx
@@ -100,8 +100,8 @@ class Footer extends React.Component {
 }
 
 Footer.propTypes = {
-    items                 : PropTypes.array,
     is_portfolio_drawer_on: PropTypes.bool,
+    items                 : PropTypes.array,
     togglePortfolioDrawer : PropTypes.func,
 };
 

--- a/src/javascript/app_2/components/layout/header.jsx
+++ b/src/javascript/app_2/components/layout/header.jsx
@@ -1,5 +1,6 @@
 import React               from 'react';
 import PerfectScrollbar    from 'react-perfect-scrollbar';
+import PropTypes           from 'prop-types';
 import AccountSwitcher     from '../elements/account_switcher.jsx';
 import {
     DrawerItem,
@@ -63,10 +64,11 @@ const DrawerFooter = () => ( // TODO: update the UI
 );
 
 class Header extends React.Component {
+
     render() {
         return (
             <React.Fragment>
-                <header id={this.props.id} className='shadow'>
+                <header className='shadow'>
                     <div className='menu-items'>
                         <div className='menu-left'>
                             <ToggleDrawer alignment='left' footer={DrawerFooter}>
@@ -150,5 +152,9 @@ const AccountBalance = connect(
         </div>
     );
 });
+
+Header.propTypes = {
+    items: PropTypes.array,
+};
 
 export default Header;

--- a/src/javascript/app_2/pages/statement/statement.jsx
+++ b/src/javascript/app_2/pages/statement/statement.jsx
@@ -1,6 +1,7 @@
 import React              from 'react';
 import moment             from 'moment';
 import classnames         from 'classnames';
+import PropTypes          from 'prop-types';
 import DAO                from '../../data/dao';
 import { connect }        from '../../store/connect';
 import Client             from '../../../_common/base/client_base';
@@ -330,8 +331,25 @@ class Statement extends React.PureComponent {
 }
 
 Statement.defaultProps = {
-    chunk_size: 50,  // display with chunks
     batch_size: 200, // request with batches
+    chunk_size: 50,  // display with chunks
+};
+
+StatementCard.propTypes = {
+    action   : PropTypes.string,
+    amount   : PropTypes.string,
+    balance  : PropTypes.string,
+    className: PropTypes.string,
+    date     : PropTypes.string,
+    desc     : PropTypes.string,
+    payout   : PropTypes.string,
+    refid    : PropTypes.string,
+};
+
+Statement.propTypes = {
+    batch_size : PropTypes.number,
+    chunk_size : PropTypes.number,
+    server_time: PropTypes.object,
 };
 
 export default connect(

--- a/src/javascript/app_2/pages/trading/actions/duration.js
+++ b/src/javascript/app_2/pages/trading/actions/duration.js
@@ -11,6 +11,7 @@ export const onChangeExpiry = ({
 }) => {
     // TODO: for contracts that only have daily, date_expiry should have a minimum of daily, not intraday
     let contract_expiry_type = expiry_type === 'duration' && duration_unit === 'd' ? 'daily' : 'intraday';
+
     if (expiry_type === 'endtime') {
         const time    = ((expiry_time.split(' ') || [])[0] || '').split(':');
         const expires = moment(expiry_date).utc();

--- a/src/javascript/app_2/pages/trading/components/amount.jsx
+++ b/src/javascript/app_2/pages/trading/components/amount.jsx
@@ -1,4 +1,5 @@
 import React        from 'react';
+import PropTypes    from 'prop-types';
 import Dropdown     from '../../../components/form/dropdown.jsx';
 import Fieldset     from '../../../components/form/fieldset.jsx';
 import InputField   from '../../../components/form/input_field.jsx';
@@ -68,6 +69,16 @@ const Amount = ({
             }
         </Fieldset>
     );
+};
+
+Amount.propTypes = {
+    amount         : PropTypes.number,
+    basis          : PropTypes.string,
+    currencies_list: PropTypes.object,
+    currency       : PropTypes.string,
+    is_minimized   : PropTypes.bool,
+    is_nativepicker: PropTypes.bool,
+    onChange       : PropTypes.func,
 };
 
 export default connect(

--- a/src/javascript/app_2/pages/trading/components/barrier.jsx
+++ b/src/javascript/app_2/pages/trading/components/barrier.jsx
@@ -1,4 +1,5 @@
 import React        from 'react';
+import PropTypes    from 'prop-types';
 import Fieldset     from '../../../components/form/fieldset.jsx';
 import InputField   from '../../../components/form/input_field.jsx';
 import { connect }  from '../../../store/connect';
@@ -56,6 +57,13 @@ const Barrier = ({
             }
         </Fieldset>
     );
+};
+
+Barrier.propTypes = {
+    barrier_1   : PropTypes.bool,
+    barrier_2   : PropTypes.bool,
+    is_minimized: PropTypes.bool,
+    onChange    : PropTypes.func,
 };
 
 export default connect(

--- a/src/javascript/app_2/pages/trading/components/contract_type.jsx
+++ b/src/javascript/app_2/pages/trading/components/contract_type.jsx
@@ -1,4 +1,5 @@
 import React          from 'react';
+import PropTypes      from 'prop-types';
 import ContractsPopUp from './elements/contracts_popup.jsx';
 import { connect }    from '../../../store/connect';
 
@@ -16,6 +17,12 @@ const Contract = ({
         {...other}
     />
 );
+
+Contract.propTypes = {
+    contract_type      : PropTypes.string,
+    contract_types_list: PropTypes.object,
+    onChange           : PropTypes.func,
+};
 
 export default connect(
     ({trade}) => ({

--- a/src/javascript/app_2/pages/trading/components/duration.jsx
+++ b/src/javascript/app_2/pages/trading/components/duration.jsx
@@ -1,5 +1,6 @@
 import moment       from 'moment';
 import React        from 'react';
+import PropTypes    from 'prop-types';
 import Datepicker   from '../../../components/form/date_picker.jsx';
 import Dropdown     from '../../../components/form/dropdown.jsx';
 import Fieldset     from '../../../components/form/fieldset.jsx';
@@ -111,6 +112,19 @@ const Duration = ({
             }
         </Fieldset>
     );
+};
+
+Duration.propTypes = {
+    duration           : PropTypes.number,
+    duration_unit      : PropTypes.string,
+    duration_units_list: PropTypes.array,
+    expiry_date        : PropTypes.string,
+    expiry_time        : PropTypes.string,
+    expiry_type        : PropTypes.string,
+    is_minimized       : PropTypes.bool,
+    is_nativepicker    : PropTypes.bool,
+    onChange           : PropTypes.func,
+    server_time        : PropTypes.object,
 };
 
 export default connect(

--- a/src/javascript/app_2/pages/trading/components/elements/contracts_popup.jsx
+++ b/src/javascript/app_2/pages/trading/components/elements/contracts_popup.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React            from 'react';
+import PropTypes        from 'prop-types';
 import FullscreenDialog from './fullscreen_dialog.jsx';
 
 class ContractsPopUp extends React.PureComponent {
@@ -144,5 +145,14 @@ const Contracts = ({
         </div>
     ))
 );
+
+ContractsPopUp.propTypes = {
+    className       : PropTypes.string,
+    is_mobile_widget: PropTypes.bool,
+    list            : PropTypes.object,
+    name            : PropTypes.string,
+    onChange        : PropTypes.func,
+    value           : PropTypes.string,
+};
 
 export default ContractsPopUp;

--- a/src/javascript/app_2/pages/trading/components/elements/fullscreen_dialog.jsx
+++ b/src/javascript/app_2/pages/trading/components/elements/fullscreen_dialog.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Url from '../../../../../_common/url';
 
 class FullscreenDialog extends React.PureComponent {
@@ -63,5 +64,15 @@ class FullscreenDialog extends React.PureComponent {
         );
     }
 }
+
+FullscreenDialog.propTypes = {
+    children: PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.object,
+    ]),
+    onClose: PropTypes.func,
+    title  : PropTypes.string,
+    visible: PropTypes.bool,
+};
 
 export default FullscreenDialog;

--- a/src/javascript/app_2/pages/trading/components/elements/mobile_widget.jsx
+++ b/src/javascript/app_2/pages/trading/components/elements/mobile_widget.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import FullscreenDialog from './fullscreen_dialog.jsx';
 
 class MobileWidget extends React.PureComponent {
@@ -24,12 +25,12 @@ class MobileWidget extends React.PureComponent {
     }
 
     render() {
-        const minimized_param_values = React.Children.map(this.props.children, child => 
+        const minimized_param_values = React.Children.map(this.props.children, child =>
             React.cloneElement(child, {
                 is_minimized: true,
             }));
 
-        const param_pickers = React.Children.map(this.props.children, child => 
+        const param_pickers = React.Children.map(this.props.children, child =>
             React.cloneElement(child, {
                 is_nativepicker: true,
             }));
@@ -39,7 +40,7 @@ class MobileWidget extends React.PureComponent {
                 <div className='mobile-widget' onClick={this.handleWidgetClick}>
                     {minimized_param_values}
                 </div>
-                
+
                 <FullscreenDialog
                     title='Set parameters'
                     visible={this.state.open}
@@ -51,5 +52,9 @@ class MobileWidget extends React.PureComponent {
         );
     }
 }
+
+MobileWidget.propTypes = {
+    children: PropTypes.array,
+};
 
 export default MobileWidget;

--- a/src/javascript/app_2/pages/trading/components/last_digit.jsx
+++ b/src/javascript/app_2/pages/trading/components/last_digit.jsx
@@ -1,4 +1,5 @@
 import React        from 'react';
+import PropTypes    from 'prop-types';
 import Dropdown     from '../../../components/form/dropdown.jsx';
 import Fieldset     from '../../../components/form/fieldset.jsx';
 import { connect }  from '../../../store/connect';
@@ -38,6 +39,13 @@ const LastDigit = ({
             />
         </Fieldset>
     );
+};
+
+LastDigit.propTypes = {
+    is_minimized   : PropTypes.number,
+    is_nativepicker: PropTypes.bool,
+    last_digit     : PropTypes.number,
+    onChange       : PropTypes.func,
 };
 
 export default connect(

--- a/src/javascript/app_2/pages/trading/components/purchase.jsx
+++ b/src/javascript/app_2/pages/trading/components/purchase.jsx
@@ -1,4 +1,5 @@
 import React        from 'react';
+import PropTypes    from 'prop-types';
 import Button       from '../../../components/form/button.jsx';
 import { connect }  from '../../../store/connect';
 import { localize } from '../../../../_common/localize';
@@ -18,6 +19,13 @@ const Purchase = ({
         ))}
     </fieldset>
 );
+
+Purchase.propTypes = {
+    trade_types: PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.object,
+    ]),
+};
 
 export default connect(
     ({trade}) => ({

--- a/src/javascript/app_2/pages/trading/components/start_date.jsx
+++ b/src/javascript/app_2/pages/trading/components/start_date.jsx
@@ -1,4 +1,5 @@
 import React        from 'react';
+import PropTypes    from 'prop-types';
 import Dropdown     from '../../../components/form/dropdown.jsx';
 import Fieldset     from '../../../components/form/fieldset.jsx';
 import TimePicker   from '../../../components/form/time_picker.jsx';
@@ -53,6 +54,16 @@ const StartDate = ({
             }
         </Fieldset>
     );
+};
+
+StartDate.propTypes = {
+    is_minimized    : PropTypes.bool,
+    is_nativepicker : PropTypes.bool,
+    onChange        : PropTypes.func,
+    server_time     : PropTypes.object,
+    start_date      : PropTypes.string,
+    start_dates_list: PropTypes.array,
+    start_time      : PropTypes.string,
 };
 
 export default connect(

--- a/src/javascript/app_2/pages/trading/components/symbol.jsx
+++ b/src/javascript/app_2/pages/trading/components/symbol.jsx
@@ -1,4 +1,5 @@
 import React       from 'react';
+import PropTypes   from 'prop-types';
 import { connect } from '../../../store/connect';
 
 const Symbol = ({
@@ -14,6 +15,12 @@ const Symbol = ({
         </select>
     </fieldset>
 );
+
+Symbol.propTypes = {
+    onChange    : PropTypes.func,
+    symbol      : PropTypes.string,
+    symbols_list: PropTypes.object,
+};
 
 export default connect(
     ({trade}) => ({

--- a/src/javascript/app_2/pages/trading/components/test.jsx
+++ b/src/javascript/app_2/pages/trading/components/test.jsx
@@ -1,4 +1,5 @@
 import React       from 'react';
+import PropTypes   from 'prop-types';
 import { connect } from '../../../store/connect';
 
 const Test = ({
@@ -11,6 +12,11 @@ const Test = ({
         {json}
     </div>
 );
+
+Test.propTypes = {
+    entries: PropTypes.array,
+    json   : PropTypes.string,
+};
 
 export default connect(
     ({trade}) => ({

--- a/src/javascript/app_2/pages/trading/trade_app.jsx
+++ b/src/javascript/app_2/pages/trading/trade_app.jsx
@@ -1,4 +1,5 @@
 import React           from 'react';
+import PropTypes       from 'prop-types';
 import Amount          from './components/amount.jsx';
 import Barrier         from './components/barrier.jsx';
 import ContractType    from './components/contract_type.jsx';
@@ -78,6 +79,14 @@ class TradeApp extends React.Component {
         );
     }
 }
+
+TradeApp.propTypes = {
+    form_components       : PropTypes.array,
+    is_portfolio_drawer_on: PropTypes.bool,
+    portfolios            : PropTypes.array,
+    server_time           : PropTypes.object,
+    togglePortfolioDrawer : PropTypes.func,
+};
 
 export default connect(
     ({ trade, ui }) => ({

--- a/src/javascript/app_2/routes.js
+++ b/src/javascript/app_2/routes.js
@@ -1,5 +1,6 @@
 import React               from 'react';
 import { Route, NavLink }  from 'react-router-dom';
+import PropTypes from 'prop-types';
 
 import Client              from '../_common/base/client_base';
 import { redirectToLogin } from '../_common/base/login';
@@ -48,4 +49,12 @@ export const BinaryLink = ({ to, children, ...props }) => {
     }
     // else
     throw new Error(`Route not found: ${to}`);
+};
+
+BinaryLink.propTypes = {
+    children: PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.object,
+    ]),
+    to: PropTypes.string,
 };

--- a/src/templates/.eslintrc.js
+++ b/src/templates/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    rules: {
+        'react/prop-types': 0,
+    }
+};

--- a/src/templates/.eslintrc.js
+++ b/src/templates/.eslintrc.js
@@ -1,3 +1,4 @@
+
 module.exports = {
     rules: {
         'react/prop-types': 0,

--- a/src/templates/README.md
+++ b/src/templates/README.md
@@ -61,7 +61,7 @@ export const Li = ({
 };
 ```
 
-- Imports with four or more arguments need to be broken down to separate lines, but lower than that should stay in one line. 
+- Imports with four or more arguments need to be broken down to separate lines, but lower than that should stay in one line.
 - Always name your components before default exporting them, for example:
 
 ```


### PR DESCRIPTION
- Short Reason
   1) We have to pass `closeBtn` and reset this.ref everytime we deal with Drawer. Reference: [StackOverflow](https://stackoverflow.com/a/43345407/7820956) 
       - Use state / props whenever possible.

    2) As our project goes big, it's good to have only one component in one file. It's better to read, function and test.

- Solution
   - Create `drawer` directory and store all the 'Drawer' related logics and files into the directory.
   - Separate `drawer.jsx` into five different files which contains each component. 
   - use MobX props value to store our state of `is_drawer_on`. (actually similar work was done for `PortfolioDrawer`. 
   - ~~Get `is_drawer_on` props value from the very parent component ('Header') and pass closeDrawer to children components.~~ Each component has access to Mobx store. So simply each component access to`is_drawer_on` props value. 