### PR TITLE
Prevent from sending incorrect data to the Back-End (Optimization - Low Priority)

### DIFF
--- a/src/javascript/app/pages/trade/event.js
+++ b/src/javascript/app/pages/trade/event.js
@@ -147,6 +147,7 @@ const TradingEvents = (() => {
          * bind event to change in duration units, populate duration and request price
          */
         getElementById('duration_units').addEventListener('change', (e) => {
+            console.log('duration units!');
             Defaults.remove('barrier', 'barrier_high', 'barrier_low');
             Process.onDurationUnitChange(e.target.value);
             Price.processPriceRequest();
@@ -371,7 +372,14 @@ const TradingEvents = (() => {
         const high_barrier_element = getElementById('barrier_high');
         high_barrier_element.addEventListener('input', CommonTrading.debounce((e) => {
             Defaults.set('barrier_high', e.target.value);
-            Price.processPriceRequest();
+            const high_barrier_value = sessionStorage.getItem('barrier_high');
+            const low_barrier_value = sessionStorage.getItem('barrier_low');
+            if (high_barrier_value > low_barrier_value) {
+                Price.processPriceRequest();
+            } else {
+                // Show error here.
+                // Change in error side.
+            }
             CommonTrading.submitForm(getElementById('websocket_form'));
         }));
         high_barrier_element.addEventListener('keypress', (ev) => {

--- a/src/javascript/app/pages/trade/event.js
+++ b/src/javascript/app/pages/trade/event.js
@@ -147,7 +147,6 @@ const TradingEvents = (() => {
          * bind event to change in duration units, populate duration and request price
          */
         getElementById('duration_units').addEventListener('change', (e) => {
-            console.log('duration units!');
             Defaults.remove('barrier', 'barrier_high', 'barrier_low');
             Process.onDurationUnitChange(e.target.value);
             Price.processPriceRequest();

--- a/src/javascript/app/pages/trade/event.js
+++ b/src/javascript/app/pages/trade/event.js
@@ -372,15 +372,9 @@ const TradingEvents = (() => {
         const high_barrier_element = getElementById('barrier_high');
         high_barrier_element.addEventListener('input', CommonTrading.debounce((e) => {
             Defaults.set('barrier_high', e.target.value);
-            const high_barrier_value = sessionStorage.getItem('barrier_high');
-            const low_barrier_value = sessionStorage.getItem('barrier_low');
-            if (high_barrier_value > low_barrier_value) {
-                Price.processPriceRequest();
-            } else {
-                // Show error here.
-                // Change in error side.
-            }
+            Price.processPriceRequest();
             CommonTrading.submitForm(getElementById('websocket_form'));
+
         }));
         high_barrier_element.addEventListener('keypress', (ev) => {
             onlyNumericOnKeypress(ev, [43, 45, 46]);

--- a/src/javascript/app/pages/trade/price.js
+++ b/src/javascript/app/pages/trade/price.js
@@ -341,35 +341,38 @@ const Price = (() => {
                     break;
             }
         }
+        const high_barrier_value = sessionStorage.getItem('barrier_high');
+        const low_barrier_value = sessionStorage.getItem('barrier_low');
 
         processForgetProposalOpenContract();
         processForgetProposals().then(() => {
             Object.keys(types || {}).forEach((type_of_contract) => {
-                BinarySocket.send(Price.proposal(type_of_contract), { callback: (response) => {
-                    if (response.echo_req && response.echo_req !== null && response.echo_req.passthrough &&
-                        response.echo_req.passthrough.form_id === form_id) {
-                        commonTrading.hideOverlayContainer();
-                        const high_barrier_value = sessionStorage.getItem('barrier_high');
-                        const low_barrier_value = sessionStorage.getItem('barrier_low');
-                        if (high_barrier_value > low_barrier_value) {
+                if (high_barrier_value > low_barrier_value) {
+                    BinarySocket.send(Price.proposal(type_of_contract), { callback: (response) => {
+                        if (response.echo_req && response.echo_req !== null && response.echo_req.passthrough &&
+                            response.echo_req.passthrough.form_id === form_id) {
+                            commonTrading.hideOverlayContainer();
                             Price.display(response, Contract.contractType()[Contract.form()]);
-                        } else {
-                            Price.display(
-                                {
-                                    echo_req: {
-                                        contract_type: 'EXPIRYRANGE',
-                                    },
-                                    error: {
-                                        message: 'High barrier must be higher than low barrier.',
-                                    },
-                                }, Contract.contractType()[Contract.form()]);
+                            commonTrading.hidePriceOverlay();
                         }
-                        commonTrading.hidePriceOverlay();
-                    }
-                } });
+                    } });
+                } else {
+                    commonTrading.hideOverlayContainer();
+                    Price.display(
+                        {
+                            echo_req: {
+                                contract_type: type_of_contract,
+                            },
+                            error: {
+                                message: 'High barrier must be higher than low barrier.',
+                            },
+                        }, Contract.contractType()[Contract.form()]
+                    );
+                    commonTrading.hidePriceOverlay();
+                }
+
             });
         });
-        // console.log('High barrier must be higher than low barrier.');
     };
 
     return {

--- a/src/javascript/app/pages/trade/price.js
+++ b/src/javascript/app/pages/trade/price.js
@@ -349,12 +349,27 @@ const Price = (() => {
                     if (response.echo_req && response.echo_req !== null && response.echo_req.passthrough &&
                         response.echo_req.passthrough.form_id === form_id) {
                         commonTrading.hideOverlayContainer();
-                        Price.display(response, Contract.contractType()[Contract.form()]);
+                        const high_barrier_value = sessionStorage.getItem('barrier_high');
+                        const low_barrier_value = sessionStorage.getItem('barrier_low');
+                        if (high_barrier_value > low_barrier_value) {
+                            Price.display(response, Contract.contractType()[Contract.form()]);
+                        } else {
+                            Price.display(
+                                {
+                                    echo_req: {
+                                        contract_type: 'EXPIRYRANGE',
+                                    },
+                                    error: {
+                                        message: 'High barrier must be higher than low barrier.',
+                                    },
+                                }, Contract.contractType()[Contract.form()]);
+                        }
                         commonTrading.hidePriceOverlay();
                     }
                 } });
             });
         });
+        // console.log('High barrier must be higher than low barrier.');
     };
 
     return {


### PR DESCRIPTION
## Observation
In Trade app page,
- form(barriers and inputs) sends `proposal` data even after it didn't pass the incorrect.

## Why should we fix this?
- There is no need to pass the wrong data to the Back-End
    - Back-End returns response with an error message. 

## Solution
- We can validate user's input and send the data on our hand (in Front-End).

## Current Fix
1. Check if the higher barrier is greater than lower barrier 
2. Re-render - Send generated param to `display`)

## Further Implementation Plan
1. Check if the validation is correct (better than checking for each barrier every time).
    - If the validation is incorrect, prevent from sending the current proposal data to the Back-End.