### PR TITLE
[new-app] mohammad/fix_subscription

### DIFF
--- a/src/javascript/app_2/Services/subscription_manager.js
+++ b/src/javascript/app_2/Services/subscription_manager.js
@@ -83,7 +83,7 @@ const SubscriptionManager = (() => {
         // callback subscribers
         const subscribers = sub_info.subscribers;
         if (subscribers.length) {
-            if (response.error && !sub_info.stream_id) { // first response returned error
+            if (!sub_info.stream_id) { // first response returned error or not a subscription (i.e. subscribed proposal_open_contract for an expired contract)
                 delete subscriptions[sub_id];
             }
             sub_info.subscribers.forEach((fnc) => {


### PR DESCRIPTION
Assume it's not a subscription when there is no stream `id` in the first response.

i.e. Subscribing `proposal_open_contract` for an expired contract is not a subscription as it won't continue streaming and it doesn't return stream `id` in response too.