### PR TITLE
[new-app] kelly/fix_incorrect_endtime_bought

### DIFF
--- a/src/javascript/app_2/Stores/Modules/Trading/Helpers/proposal.js
+++ b/src/javascript/app_2/Stores/Modules/Trading/Helpers/proposal.js
@@ -40,7 +40,7 @@ const createProposalRequestForContract = (store, type_of_contract) => {
     const obj_expiry = {};
     if (store.expiry_type === 'endtime') {
         const expiry_date = moment.utc(store.expiry_date);
-        const start_date  = moment.unix(store.start_date || store.server_time).utc();
+        const start_date  = moment.unix(store.start_date || (store.server_time / 1000)).utc();
         const is_same_day = expiry_date.isSame(start_date, 'day');
         const expiry_time = is_same_day ? store.expiry_time : '23:59:59';
         obj_expiry.date_expiry = convertToUnix(expiry_date.unix(), expiry_time);

--- a/src/javascript/app_2/Stores/Modules/Trading/Helpers/proposal.js
+++ b/src/javascript/app_2/Stores/Modules/Trading/Helpers/proposal.js
@@ -40,7 +40,7 @@ const createProposalRequestForContract = (store, type_of_contract) => {
     const obj_expiry = {};
     if (store.expiry_type === 'endtime') {
         const expiry_date = moment.utc(store.expiry_date);
-        const start_date  = moment.unix(store.start_date || (store.server_time / 1000)).utc();
+        const start_date  = moment.unix(store.start_date || (store.root_store.common.server_time / 1000)).utc();
         const is_same_day = expiry_date.isSame(start_date, 'day');
         const expiry_time = is_same_day ? store.expiry_time : '23:59:59';
         obj_expiry.date_expiry = convertToUnix(expiry_date.unix(), expiry_time);

--- a/src/javascript/app_2/Stores/Modules/Trading/trade_store.js
+++ b/src/javascript/app_2/Stores/Modules/Trading/trade_store.js
@@ -259,6 +259,7 @@ export default class TradeStore extends BaseStore {
 
     @action.bound
     requestProposal() {
+        this.server_time = this.root_store.common.server_time; // pass server_time from common_store
         const requests = createProposalRequests(this);
 
         if (Object.values(this.validation_errors).some(e => e.length)) {

--- a/src/javascript/app_2/Stores/Modules/Trading/trade_store.js
+++ b/src/javascript/app_2/Stores/Modules/Trading/trade_store.js
@@ -259,7 +259,6 @@ export default class TradeStore extends BaseStore {
 
     @action.bound
     requestProposal() {
-        this.server_time = this.root_store.common.server_time; // pass server_time from common_store
         const requests = createProposalRequests(this);
 
         if (Object.values(this.validation_errors).some(e => e.length)) {


### PR DESCRIPTION
- use server_time if selected start time is 'now'