### PR TITLE
Update Package lock to match package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12075,9 +12075,9 @@
       }
     },
     "smartcharts-beta": {
-      "version": "0.3.96",
-      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.3.96.tgz",
-      "integrity": "sha512-l66ZHpRfmfxjJxhss4B7spBBhtwH4o28sJwi715M9rVMpykNPnvy3JnCA5q0/PvdDQ4azoc1IWIYvmjf1TO86g==",
+      "version": "0.3.97",
+      "resolved": "https://registry.npmjs.org/smartcharts-beta/-/smartcharts-beta-0.3.97.tgz",
+      "integrity": "sha512-3Ie9WTejRGHsF02BLfAz3gig5Huj+bYqn3pd+nZ9BTgMGKSGd1SOtxscReCzkDlYKPh46wKB/9h+0mLqY7BjpQ==",
       "requires": {
         "event-emitter-es6": "^1.1.5",
         "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
npm ERR! Invalid: lock file's smartcharts-beta@0.3.96 does not satisfy smartcharts-beta@0.3.97
