### PR TITLE
negarn/consistent_footer_link_wording

### DIFF
--- a/src/templates/static/_layout/footer.jsx
+++ b/src/templates/static/_layout/footer.jsx
@@ -107,7 +107,7 @@ const Footer = () => (
                                     { text: it.L('API'),                        href: 'https://developers.binary.com', target: '_blank' },
                                     { text: it.L('Binary Shop'),                href: 'https://shop.binary.com',       target: '_blank' },
                                     /* { text: it.L('Charitable Activities'),   href: it.url_for('charity') }, */
-                                    { text: it.L('Other Partnership Options'),    href: it.url_for('partners') },
+                                    { text: it.L('All Partnership Options'),    href: it.url_for('partners') },
                                 ]}
                             />
                         </div>


### PR DESCRIPTION
revert back to All instead of Other as it was changed mistakenly