### PR TITLE
Hubert / fixing deactivated account page visibility when user is logged in.

### DIFF
--- a/src/javascript/app/base/binary_loader.js
+++ b/src/javascript/app/base/binary_loader.js
@@ -108,6 +108,7 @@ const BinaryLoader = (() => {
         no_mf            : () => localize('Binary options trading is not available in your financial account.'),
         options_blocked  : () => localize('Binary options trading is not available in your country.'),
         residence_blocked: () => localize('This page is not available in your country of residence.'),
+        not_deactivated  : () => localize('This page is only visible, when you deactivate your account.'),
     };
 
     const loadHandler = (this_page) => {

--- a/src/javascript/app/base/binary_loader.js
+++ b/src/javascript/app/base/binary_loader.js
@@ -108,7 +108,7 @@ const BinaryLoader = (() => {
         no_mf            : () => localize('Binary options trading is not available in your financial account.'),
         options_blocked  : () => localize('Binary options trading is not available in your country.'),
         residence_blocked: () => localize('This page is not available in your country of residence.'),
-        not_deactivated  : () => localize('This page is only visible, when you deactivate your account.'),
+        not_deactivated  : () => localize('Page not available, you did not deactivate your account.'),
     };
 
     const loadHandler = (this_page) => {

--- a/src/javascript/app/base/logged_in.js
+++ b/src/javascript/app/base/logged_in.js
@@ -34,7 +34,7 @@ const LoggedInHandler = (() => {
             // redirect back
             let set_default = true;
             if (redirect_url) {
-                const do_not_redirect = ['trading_reset_passwordws', 'reset_passwordws', 'lost_passwordws', 'change_passwordws', 'home', '404'];
+                const do_not_redirect = ['trading_reset_passwordws', 'reset_passwordws', 'lost_passwordws', 'change_passwordws', 'deactivated-account', 'home', '404'];
                 const reg             = new RegExp(do_not_redirect.join('|'), 'i');
                 if (!reg.test(redirect_url) && urlFor('') !== redirect_url) {
                     set_default = false;


### PR DESCRIPTION
The deactivated account page is visible for users who are logged in, even if the user didn't deactivate his/her account. Now an error message displays if the user accesses this page while logged in. The code was already written, but I accidentally forgot to write the error message.