### PR TITLE
Hubert / Fixing barrier inputs which allow an infinite length of characters.

### DIFF
--- a/src/templates/app/trade/trading.jsx
+++ b/src/templates/app/trade/trading.jsx
@@ -94,7 +94,7 @@ const Trading = () => (
                                             </label>
                                         </div>
                                         <div className='big-col'>
-                                            <input id='barrier' type='text' data-lpignore='true' name='H' autoComplete='off' />
+                                            <input id='barrier' maxLength='20' type='text' data-lpignore='true' name='H' autoComplete='off' />
                                             <span id='indicative_barrier_tooltip' data-balloon={it.L('This is an indicative barrier. Actual barrier will be the entry spot plus the barrier offset.')} data-balloon-length='xlarge' />
                                         </div>
                                     </div>
@@ -106,7 +106,7 @@ const Trading = () => (
                                             </label>
                                         </div>
                                         <div className='big-col'>
-                                            <input id='barrier_high' type='text' data-lpignore='true' name='H' autoComplete='off' />
+                                            <input id='barrier_high' maxLength='20' type='text' data-lpignore='true' name='H' autoComplete='off' />
                                             <span id='indicative_high_barrier_tooltip' data-balloon={it.L('This is an indicative barrier. Actual barrier will be the entry spot plus the barrier offset.')} data-balloon-length='xlarge' />
                                             <div className='hint'>
                                                 <span id='barrier_high_error' className='error-msg invisible'>{it.L('High barrier must be higher than low barrier')}</span>
@@ -121,7 +121,7 @@ const Trading = () => (
                                             </label>
                                         </div>
                                         <div className='big-col'>
-                                            <input id='barrier_low' type='text' data-lpignore='true' name='L' autoComplete='off' />
+                                            <input id='barrier_low' maxLength='20' type='text' data-lpignore='true' name='L' autoComplete='off' />
                                             <span id='indicative_low_barrier_tooltip' data-balloon={it.L('This is an indicative barrier. Actual barrier will be the entry spot plus the barrier offset.')} data-balloon-length='xlarge' />
                                         </div>
                                     </div>


### PR DESCRIPTION
After more than 20 characters, a back-end error will occur suggesting that there are too many characters in the input. For now I simply added a maxLength='20' on the barrier inputs to prevent this.