### PR TITLE
amam/fix_translation_config

### DIFF
--- a/.github/workflows/sync_crowdin_translations.yml
+++ b/.github/workflows/sync_crowdin_translations.yml
@@ -23,9 +23,6 @@ jobs:
 
       - name: Checkout master branch
         uses: actions/checkout@v2
-        with:
-          repository: "binary-com/binary-static"
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - name: Setup Project and environment
         run: |
@@ -93,7 +90,7 @@ jobs:
             git push --set-upstream origin "$branch_name" -f
 
             sudo apt install gh
-            gh auth login --with-token <<< ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+            gh auth login --with-token <<< ${{ github.token }}
             gh pr close "$branch_name" || true
             gh pr create --fill --base "master" --head "binary-com:$branch_name"
 


### PR DESCRIPTION
- github action do not allowed authentication from PAT on checkout package
- by default action/checkout will use github.token as token to authenticate