### PR TITLE
MaryiaF/refactor: subscribe proposal_open_contract globally without s…

### DIFF
--- a/src/javascript/_common/base/socket_base.js
+++ b/src/javascript/_common/base/socket_base.js
@@ -180,9 +180,6 @@ const BinarySocketBase = (() => {
 
         if (isReady() && !availability.is_down && config.isOnline()) {
             is_disconnect_called = false;
-            if (!getPropertyValue(data, 'passthrough') && !getPropertyValue(data, 'verify_email')) {
-                data.passthrough = {};
-            }
 
             binary_socket.send(JSON.stringify(data));
             config.wsEvent('send');

--- a/src/javascript/app/pages/trade/purchase.js
+++ b/src/javascript/app/pages/trade/purchase.js
@@ -227,7 +227,7 @@ const Purchase = (() => {
                 proposal_open_contract: 1,
                 subscribe             : 1,
             };
-            BinarySocket.send(request, { callback: (response) => {
+            BinarySocket.send(request).then((response) => {
                 const mw_response = response.proposal_open_contract ? changePocNumbersToString(response) : undefined;
                 const contract = mw_response ? mw_response.proposal_open_contract : undefined;
                 if (contract) {
@@ -245,7 +245,7 @@ const Purchase = (() => {
                         sellExpired();
                     }
                 }
-            } });
+            });
         }
     };
 

--- a/src/javascript/app/pages/trade/purchase.js
+++ b/src/javascript/app/pages/trade/purchase.js
@@ -225,7 +225,6 @@ const Purchase = (() => {
         if (show_chart) {
             const request = {
                 proposal_open_contract: 1,
-                contract_id           : receipt.contract_id,
                 subscribe             : 1,
             };
             BinarySocket.send(request, { callback: (response) => {


### PR DESCRIPTION
…pecific contract_id, use same approach as in Deriv

During open contact mode runtime subscribe request happens with proposal_open_contract globally, without specific contract_id.