### PR TITLE
Meenu/redirect row users move to deriv url

### DIFF
--- a/src/javascript/app/common/redirect_banner.js
+++ b/src/javascript/app/common/redirect_banner.js
@@ -1,3 +1,4 @@
+const Cookies          = require('js-cookie');
 const DerivBanner = require('./deriv_banner');
 const BinarySocket = require('../base/socket');
 const State = require('../../_common/storage').State;
@@ -12,6 +13,8 @@ const RedirectBanner = (() => {
             const eu_country = isEuCountrySelected(Client.get('residence')) || isEuCountrySelected(State.getResponse('website_status.clients_country'));
             if (eu_country) {
                 handleRedirect();
+            } else {
+                handleRedirectROW();
             }
             
         });
@@ -20,6 +23,23 @@ const RedirectBanner = (() => {
 
     const handleRedirect = () => {
         window.location.href = '/move-to-deriv/';
+    
+    };
+    
+    const handleRedirectROW = () => {
+        
+        // Check if param have ?binary-com-lp
+        const redirectBinary = new URLSearchParams(window.location.search);
+        const date = new Date();
+        date.setTime(date.getTime()+(2*60*1000));
+       
+        if (redirectBinary.has('binary-com-lp') || Cookies.get('binary-com-show')){
+            // Set cookie if they wanted to stay at binary.com and no redirect
+            Cookies.set('binary-com-show', true, { expires: date });
+        } else {
+            window.location.replace('https://binary.bot/move-to-deriv');
+        }
+    
     };
 
     const loginOnLoad = () => {


### PR DESCRIPTION
- Redirect users from binary.com to https://binary.bot/move-to-deriv

- If users do not want to redirect > take them to binary.com and setup a cookie for 7 days.